### PR TITLE
feat(input): prevent automatic corrections

### DIFF
--- a/src/views/index.html
+++ b/src/views/index.html
@@ -58,7 +58,7 @@
 
     <section>
       <div class="left-column" id="code-screen">
-        <input id="css-input" placeholder="Enter CSS selector here" />
+        <input id="css-input" placeholder="Enter CSS selector here" autocorrect="off" autocomplete="off" autocapitalize="off" spellcheck="false" />
         <button id="submit">-></button>
         <div class="codebox">
           <pre><code id="html-goal" class="language-markup"></code></pre>


### PR DESCRIPTION
I lost a couple seconds fixing my browser helpfully changing "li" into "lui" for example, and on iOS it would have automatically capitalised the start, which wouldn't be valid here