### PR TITLE
fix make font size related unit em

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -226,7 +226,7 @@ main section {
     li {
       width: 100%;
       opacity: 0.2;
-      height: 24.8px;
+      height: 1.5em;
       margin: 0;
     }
 


### PR DESCRIPTION
A long time ago I've set some minimum font size in my browser... the highlights for matched lines are all over the place because of the fixed font size in your css. 1.5em fixes things up nicely ;-)